### PR TITLE
Add support for Filesystem driver VM

### DIFF
--- a/src/c/sdfgen.h
+++ b/src/c/sdfgen.h
@@ -143,3 +143,7 @@ bool sdfgen_lionsos_fs_fat_connect(void *system);
 void *sdfgen_lionsos_fs_nfs(void *sdf, void *fs, void *client, void *net, void *net_copier, uint8_t mac_addr[6], void *serial, void *timer);
 bool sdfgen_lionsos_fs_nfs_connect(void *system);
 bool sdfgen_lionsos_fs_nfs_serialise_config(void *system, char *output_dir);
+
+void *sdfgen_lionsos_fs_vmfs(void *sdf, void *fs_vm_sys, void *client, void *blk, void *virtio_device, uint32_t partition);
+bool sdfgen_lionsos_fs_vmfs_connect(void *system);
+bool sdfgen_lionsos_fs_vmfs_serialise_config(void *system, char *output_dir);

--- a/src/dtb.zig
+++ b/src/dtb.zig
@@ -205,13 +205,13 @@ pub const LinuxUio = struct {
 
         const dt_paddr = dt_reg[0][0];
         if (dt_paddr % arch.defaultPageSize() != 0) {
-            log.err("Encountered UIO node '{s}' with paddr 0x{x} isn't a multiple of page size", .{ node.name, dt_paddr });
+            log.err("expected UIO device '{s}' region to be page aligned, found non-page aligned address: 0x{x}", .{ node.name, dt_paddr });
             return error.InvalidUio;
         }
 
         const dt_size = dt_reg[0][1];
         if (dt_size % arch.defaultPageSize() != 0) {
-            log.err("Encountered UIO node '{s}' with size {x} isn't a multiple of page size", .{ node.name, dt_size });
+            log.err("expected UIO device '{s}' region size to be page aligned, found non-page aligned size: 0x{x}", .{ node.name, dt_paddr });
             return error.InvalidUio;
         }
 

--- a/src/sddf.zig
+++ b/src/sddf.zig
@@ -325,6 +325,7 @@ pub const Timer = struct {
     clients: std.ArrayList(*Pd),
     client_configs: std.ArrayList(ConfigResources.Timer.Client),
     connected: bool = false,
+    serialised: bool = false,
 
     pub const Error = SystemError;
 
@@ -401,6 +402,8 @@ pub const Timer = struct {
             const data_name = fmt(allocator, "timer_client_{s}", .{client.name});
             try data.serialize(allocator, system.client_configs.items[i], prefix, data_name);
         }
+
+        system.serialised = true;
     }
 };
 
@@ -420,6 +423,7 @@ pub const I2c = struct {
     client_configs: std.ArrayList(ConfigResources.I2c.Client),
     num_buffers: u16,
     connected: bool = false,
+    serialised: bool = false,
 
     pub const Error = SystemError;
 
@@ -617,6 +621,8 @@ pub const I2c = struct {
             const name = fmt(allocator, "i2c_client_{s}", .{client.name});
             try data.serialize(allocator, system.client_configs.items[i], prefix, name);
         }
+
+        system.serialised = true;
     }
 };
 
@@ -630,6 +636,7 @@ pub const Blk = struct {
     clients: std.ArrayList(*Pd),
     client_partitions: std.ArrayList(u32),
     connected: bool = false,
+    serialised: bool = false,
     // TODO: make this configurable per component
     queue_mr_size: usize = 2 * 1024 * 1024,
     // TODO: make configurable
@@ -854,6 +861,8 @@ pub const Blk = struct {
             const client_config = fmt(allocator, "blk_client_{s}", .{system.clients.items[i].name});
             try data.serialize(allocator, config, prefix, client_config);
         }
+
+        system.serialised = true;
     }
 };
 
@@ -870,6 +879,7 @@ pub const Serial = struct {
     clients: std.ArrayList(*Pd),
     connected: bool = false,
     enable_color: bool,
+    serialised: bool = false,
 
     driver_config: ConfigResources.Serial.Driver,
     virt_rx_config: ConfigResources.Serial.VirtRx,
@@ -1033,6 +1043,8 @@ pub const Serial = struct {
             const data_name = fmt(allocator, "serial_client_{s}", .{client.name});
             try data.serialize(allocator, system.client_configs.items[i], prefix, data_name);
         }
+
+        system.serialised = true;
     }
 };
 
@@ -1080,6 +1092,7 @@ pub const Net = struct {
     client_configs: std.ArrayList(ConfigResources.Net.Client),
 
     connected: bool = false,
+    serialised: bool = false,
 
     rx_buffers: usize,
     client_info: std.ArrayList(ClientInfo),
@@ -1349,6 +1362,8 @@ pub const Net = struct {
             const data_name = fmt(allocator, "net_client_{s}", .{client.name});
             try data.serialize(allocator, system.client_configs.items[i], prefix, data_name);
         }
+
+        system.serialised = true;
     }
 };
 
@@ -1361,6 +1376,7 @@ pub const Gpu = struct {
     virt: *Pd,
     clients: std.ArrayList(*Pd),
     connected: bool = false,
+    serialised: bool = false,
     config: Gpu.Config,
     // Configurable parameters. Right now we just hard-code
     // these.
@@ -1561,6 +1577,8 @@ pub const Gpu = struct {
             const client_data = fmt(allocator, "gpu_client_{s}", .{system.clients.items[i].name});
             try data.serialize(allocator, config, prefix, client_data);
         }
+
+        system.serialised = true;
     }
 };
 

--- a/src/vmm.zig
+++ b/src/vmm.zig
@@ -323,19 +323,20 @@ fn parseUios(system: *Self) !void {
         if (compatibles.len != 2) {
             // NULL must be used as the delimiter as the DTB parser assumes NULL.
             log.err("Compatibile string {s} isn't in the expected format of 'generic-uio\\0<name>'.", .{ node.prop(.Compatible).? });
-            @panic("todo");
+            return error.InvalidUio;
         }
         const node_name = compatibles[1];
 
         if (node_name.len > UIO_NAME_LEN - 1) {
             log.err("Encountered UIO node '{s}', with name of length {d}, greater than limit of {d}.", .{ node_name, node_name.len, UIO_NAME_LEN - 1 });
-            @panic("todo");
+            return error.InvalidUio;
         }
         if (system.findUio(node_name) != null) {
-            @panic("todo");
+            log.err("Encountered UIO node with duplicate name: {s}", .{node_name});
+            return error.InvalidUio;
         }
 
-        const uio_node = dtb.LinuxUio.create(allocator, node, system.sdf.arch);
+        const uio_node = try dtb.LinuxUio.create(allocator, node, system.sdf.arch);
 
         system.data.linux_uios[i] = .{
             .name = undefined,


### PR DESCRIPTION
This PR add support for driver VM based Filesystems to the tool.

The corresponding example system is in: https://github.com/au-ts/lionsos/pull/143

The user must write the correct UIO nodes in their device tree for the tool to parse and create the appropriate data structures and memory mappings.

Notes:
- The VMM config data structure has updated to include UIO regions. This will require updating `config.h` in libvmm. An updated `config.h` is currently in a branch: https://github.com/au-ts/libvmm/blob/sdfgen_update/include/libvmm/config.h
- The order of connections are important, and all config serialisation must happen after connection. For example things must happen in this order:
```python
    assert fs_vm_system.connect()
    assert fs_system.connect()
    assert blk_system.connect()
    assert fs_vm_system.serialise_config(output_dir)
    assert fs_system.serialise_config(output_dir)
    assert blk_system.serialise_config(output_dir)
```  
Interweaving `connect()` and `serialise_config()` like this won't work:
```python
    assert fs_vm_system.connect()
    assert fs_vm_system.serialise_config(output_dir)
    assert fs_system.connect()
    assert fs_system.serialise_config(output_dir)
    assert blk_system.connect()
    assert blk_system.serialise_config(output_dir)
```
Because `fs_system.connect()` triggers a memory mapping of the shared configuration data region between guest and VMM in `fs_vm_system`. So all the `connect()` must happen before `serialise_config`.