### PR TITLE
Adds Pinctrl device class

### DIFF
--- a/src/c/c.zig
+++ b/src/c/c.zig
@@ -691,6 +691,48 @@ export fn sdfgen_sddf_gpu_serialise_config(system: *align(8) anyopaque, output_d
     return true;
 }
 
+export fn sdfgen_sddf_pinctrl(c_sdf: *align(8) anyopaque, c_device: ?*align(8) anyopaque, driver: *align(8) anyopaque) *anyopaque {
+    const sdf: *SystemDescription = @ptrCast(c_sdf);
+    const pinctrl = allocator.create(sddf.Pinctrl) catch @panic("OOM");
+    pinctrl.* = sddf.Pinctrl.init(allocator, sdf, @ptrCast(c_device), @ptrCast(driver));
+
+    return pinctrl;
+}
+
+export fn sdfgen_sddf_pinctrl_destroy(system: *align(8) anyopaque) void {
+    const pinctrl: *sddf.Pinctrl = @ptrCast(system);
+    pinctrl.deinit();
+    allocator.destroy(pinctrl);
+}
+
+export fn sdfgen_sddf_pinctrl_add_client(system: *align(8) anyopaque, client: *align(8) anyopaque) bindings.sdfgen_sddf_status_t {
+    const pinctrl: *sddf.Pinctrl = @ptrCast(system);
+    pinctrl.addClient(@ptrCast(client)) catch |e| {
+        switch (e) {
+            sddf.Pinctrl.Error.DuplicateClient => return 1,
+            sddf.Pinctrl.Error.InvalidClient => return 2,
+            // Should never happen when adding a client
+            sddf.Pinctrl.Error.NotConnected => @panic("internal error"),
+        }
+    };
+
+    return 0;
+}
+
+export fn sdfgen_sddf_pinctrl_connect(system: *align(8) anyopaque) bool {
+    const pinctrl: *sddf.Pinctrl = @ptrCast(system);
+    pinctrl.connect() catch return false;
+
+    return true;
+}
+
+export fn sdfgen_sddf_pinctrl_serialise_config(system: *align(8) anyopaque, output_dir: [*c]u8) bool {
+    const pinctrl: *sddf.Pinctrl = @ptrCast(system);
+    pinctrl.serialiseConfig(std.mem.span(output_dir)) catch return false;
+
+    return true;
+}
+
 export fn sdfgen_vmm(c_sdf: *align(8) anyopaque, vmm_pd: *align(8) anyopaque, vm: *align(8) anyopaque, c_dtb: *align(8) anyopaque, dtb_size: u64, one_to_one_ram: bool) *anyopaque {
     const sdf: *SystemDescription = @ptrCast(c_sdf);
     const vmm = allocator.create(Vmm) catch @panic("OOM");

--- a/src/c/sdfgen.h
+++ b/src/c/sdfgen.h
@@ -130,6 +130,12 @@ sdfgen_sddf_status_t sdfgen_sddf_gpu_add_client(void *system, void *client);
 bool sdfgen_sddf_gpu_connect(void *system);
 bool sdfgen_sddf_gpu_serialise_config(void *system, char *output_dir);
 
+void *sdfgen_sddf_pinctrl(void *sdf, void *device, void *driver);
+void sdfgen_sddf_pinctrl_destroy(void *system);
+sdfgen_sddf_status_t sdfgen_sddf_pinctrl_add_client(void *system, void *client);
+bool sdfgen_sddf_pinctrl_connect(void *system);
+bool sdfgen_sddf_pinctrl_serialise_config(void *system, char *output_dir);
+
 /*** Virtual Machine Monitor ***/
 void *sdfgen_vmm(void *sdf, void *vmm_pd, void *vm, char *name, void *dtb, bool one_to_one_ram);
 bool sdfgen_vmm_add_passthrough_device(void *vmm, char *name, void *device);

--- a/src/data.zig
+++ b/src/data.zig
@@ -339,6 +339,15 @@ pub const Resources = struct {
         };
     };
 
+    pub const Pinctrl = struct {
+        const MAGIC: [5]u8 = MAGIC_START ++ .{0x8};
+
+        pub const Client = extern struct {
+            magic: [5]u8 = MAGIC,
+            driver_id: u8,
+        };
+    };
+
     pub const Fs = extern struct {
         const MAGIC: [8]u8 = LIONS_MAGIC_START ++ .{0x1};
 

--- a/src/python/module.py
+++ b/src/python/module.py
@@ -141,6 +141,19 @@ libsdfgen.sdfgen_sddf_timer_connect.argtypes = [c_void_p]
 libsdfgen.sdfgen_sddf_timer_serialise_config.restype = c_bool
 libsdfgen.sdfgen_sddf_timer_serialise_config.argtypes = [c_void_p, c_char_p]
 
+libsdfgen.sdfgen_sddf_pinctrl.restype = c_void_p
+libsdfgen.sdfgen_sddf_pinctrl.argtypes = [c_void_p, c_void_p, c_void_p]
+libsdfgen.sdfgen_sddf_pinctrl_destroy.restype = None
+libsdfgen.sdfgen_sddf_pinctrl_destroy.argtypes = [c_void_p]
+
+libsdfgen.sdfgen_sddf_pinctrl_add_client.restype = c_uint32
+libsdfgen.sdfgen_sddf_pinctrl_add_client.argtypes = [c_void_p, c_void_p]
+
+libsdfgen.sdfgen_sddf_pinctrl_connect.restype = c_bool
+libsdfgen.sdfgen_sddf_pinctrl_connect.argtypes = [c_void_p]
+libsdfgen.sdfgen_sddf_pinctrl_serialise_config.restype = c_bool
+libsdfgen.sdfgen_sddf_pinctrl_serialise_config.argtypes = [c_void_p, c_char_p]
+
 libsdfgen.sdfgen_sddf_i2c.restype = c_void_p
 libsdfgen.sdfgen_sddf_i2c.argtypes = [c_void_p, c_void_p, c_void_p, c_void_p]
 libsdfgen.sdfgen_sddf_i2c_destroy.restype = None
@@ -999,6 +1012,43 @@ class Sddf:
 
         def __del__(self):
             libsdfgen.sdfgen_sddf_gpu_destroy(self._obj)
+
+    class Pinctrl:
+        _obj: c_void_p
+
+        def __init__(
+            self,
+            sdf: SystemDescription,
+            device: Optional[DeviceTree.Node],
+            driver: SystemDescription.ProtectionDomain
+        ) -> None:
+            if device is None:
+                device_obj = None
+            else:
+                device_obj = device._obj
+
+            self._obj: c_void_p = libsdfgen.sdfgen_sddf_pinctrl(sdf._obj, device_obj, driver._obj)
+
+        def add_client(self, client: SystemDescription.ProtectionDomain):
+            ret = libsdfgen.sdfgen_sddf_pinctrl_add_client(self._obj, client._obj)
+            if ret == SddfStatus.OK:
+                return
+            elif ret == SddfStatus.DUPLICATE_CLIENT:
+                raise Exception(f"duplicate client given '{client}'")
+            elif ret == SddfStatus.INVALID_CLIENT:
+                raise Exception(f"invalid client given '{client}'")
+            else:
+                raise Exception(f"internal error: {ret}")
+
+        def connect(self) -> bool:
+            return libsdfgen.sdfgen_sddf_pinctrl_connect(self._obj)
+
+        def serialise_config(self, output_dir: str) -> bool:
+            c_output_dir = c_char_p(output_dir.encode("utf-8"))
+            return libsdfgen.sdfgen_sddf_pinctrl_serialise_config(self._obj, c_output_dir)
+
+        def __del__(self):
+            libsdfgen.sdfgen_sddf_pinctrl_destroy(self._obj)
 
     class Lwip:
         _obj: c_void_p

--- a/src/sddf.zig
+++ b/src/sddf.zig
@@ -282,6 +282,7 @@ pub const Config = struct {
             blk,
             i2c,
             gpu,
+            pinctrl,
 
             pub fn fromStr(str: []const u8) ?Class {
                 inline for (std.meta.fields(Class)) |field| {
@@ -301,6 +302,7 @@ pub const Config = struct {
                     .blk => &.{ "blk", "blk/mmc" },
                     .i2c => &.{"i2c"},
                     .gpu => &.{"gpu"},
+                    .pinctrl => &.{"pinctrl"},
                 };
             }
         };
@@ -1617,6 +1619,100 @@ pub const Gpu = struct {
         for (system.config.clients.items, 0..) |config, i| {
             const client_data = fmt(allocator, "gpu_client_{s}", .{system.clients.items[i].name});
             try data.serialize(allocator, config, prefix, client_data);
+        }
+
+        system.serialised = true;
+    }
+};
+
+pub const Pinctrl = struct {
+    allocator: Allocator,
+    sdf: *SystemDescription,
+    /// Protection Domain that will act as the driver for the pinmux device
+    driver: *Pd,
+    /// Device Tree node for the pinctrl device
+    device: *dtb.Node,
+    device_res: ConfigResources.Device,
+    /// Client PDs serviced by the pinctrl driver
+    clients: std.ArrayList(*Pd),
+    client_configs: std.ArrayList(ConfigResources.Pinctrl.Client),
+    connected: bool = false,
+    serialised: bool = false,
+
+    pub const Error = SystemError;
+
+    pub fn init(allocator: Allocator, sdf: *SystemDescription, device: *dtb.Node, driver: *Pd) Pinctrl {
+        // First we have to set some properties on the driver. It is currently our policy that every pinctrl
+        // driver should be passive.
+        driver.passive = true;
+
+        return .{
+            .allocator = allocator,
+            .sdf = sdf,
+            .driver = driver,
+            .device = device,
+            .device_res = std.mem.zeroInit(ConfigResources.Device, .{}),
+            .clients = std.ArrayList(*Pd).init(allocator),
+            .client_configs = std.ArrayList(ConfigResources.Pinctrl.Client).init(allocator),
+        };
+    }
+
+    pub fn deinit(system: *Pinctrl) void {
+        system.clients.deinit();
+        system.client_configs.deinit();
+    }
+
+    pub fn addClient(system: *Pinctrl, client: *Pd) Error!void {
+        // Check that the client does not already exist
+        for (system.clients.items) |existing_client| {
+            if (std.mem.eql(u8, existing_client.name, client.name)) {
+                return Error.DuplicateClient;
+            }
+        }
+        if (std.mem.eql(u8, client.name, system.driver.name)) {
+            log.err("invalid pinctrl client, same name as driver '{s}", .{client.name});
+            return Error.InvalidClient;
+        }
+        const client_priority = if (client.priority) |priority| priority else Pd.DEFAULT_PRIORITY;
+        const driver_priority = if (system.driver.priority) |priority| priority else Pd.DEFAULT_PRIORITY;
+        if (client_priority >= driver_priority) {
+            log.err("invalid pinctrl client '{s}', driver '{s}' must have greater priority than client", .{ client.name, system.driver.name });
+            return Error.InvalidClient;
+        }
+        system.clients.append(client) catch @panic("Could not add client to Pinctrl");
+        system.client_configs.append(std.mem.zeroInit(ConfigResources.Pinctrl.Client, .{})) catch @panic("Could not add client to Timer");
+    }
+
+    pub fn connect(system: *Pinctrl) !void {
+        // The driver must be passive
+        assert(system.driver.passive.?);
+
+        try createDriver(system.sdf, system.driver, system.device, .pinctrl, &system.device_res);
+        for (system.clients.items, 0..) |client, i| {
+            const ch = Channel.create(system.driver, client, .{
+                // Client needs to be able to PPC into driver
+                .pp = .b,
+                // Client does not need to notify driver
+                .pd_b_notify = false,
+            }) catch unreachable;
+            system.sdf.addChannel(ch);
+            system.client_configs.items[i].driver_id = ch.pd_b_id;
+        }
+
+        system.connected = true;
+    }
+
+    pub fn serialiseConfig(system: *Pinctrl, prefix: []const u8) !void {
+        if (!system.connected) return Error.NotConnected;
+
+        const allocator = system.allocator;
+
+        const device_res_data_name = fmt(allocator, "{s}_device_resources", .{system.driver.name});
+        try data.serialize(allocator, system.device_res, prefix, device_res_data_name);
+
+        for (system.clients.items, 0..) |client, i| {
+            const data_name = fmt(allocator, "pinctrl_client_{s}", .{client.name});
+            try data.serialize(allocator, system.client_configs.items[i], prefix, data_name);
         }
 
         system.serialised = true;


### PR DESCRIPTION
This PR adds the Pinctrl device class for sDDF.

Currently, it operates exactly like a timer driver, except there is no interrupts.

There is an outstanding issue to be solved:
- [ ] On the imx8 and meson platforms, the pinctrl device is composed of 2 discrete device tree nodes and memory regions. Currently the pinctrl subsystem can only be instantiated with 1 DT node. While this is sufficient for basic functionality on the imx8, it is insufficient for the meson. We would need to come up with a clean way of expressing this in the Zig code, `config.json` and public API.