### PR TITLE
Improve support for `setvar_*` attributes

### DIFF
--- a/src/c/c.zig
+++ b/src/c/c.zig
@@ -300,7 +300,7 @@ export fn sdfgen_sddf_init(path: [*c]u8) bool {
     return true;
 }
 
-export fn sdfgen_irq_create(number: u32, c_trigger: [*c]bindings.sdfgen_irq_trigger_t, c_id: [*c]u8) ?*anyopaque {
+export fn sdfgen_irq_create(number: u32, c_trigger: [*c]bindings.sdfgen_irq_trigger_t, c_id: [*c]u8, c_setvar_id: ?[*:0]u8) ?*anyopaque {
     const irq = allocator.create(Irq) catch @panic("OOM");
     var options: Irq.Options = .{};
     if (c_trigger != null) {
@@ -318,13 +318,16 @@ export fn sdfgen_irq_create(number: u32, c_trigger: [*c]bindings.sdfgen_irq_trig
     if (c_id != null) {
         options.id = c_id.*;
     }
+    if (c_setvar_id) |s| {
+        options.setvar_id = allocator.dupe(u8, std.mem.span(s)) catch @panic("OOM");
+    }
 
     irq.* = Irq.create(number, options);
 
     return irq;
 }
 
-export fn sdfgen_irq_ioapic_create(ioapic: u64, pin: u64, c_trigger: [*c]bindings.sdfgen_irq_trigger_t, c_polarity: [*c]bindings.sdfgen_irq_ioapic_polarity_t, vector: u64, c_id: [*c]u8) ?*anyopaque {
+export fn sdfgen_irq_ioapic_create(ioapic: u64, pin: u64, c_trigger: [*c]bindings.sdfgen_irq_trigger_t, c_polarity: [*c]bindings.sdfgen_irq_ioapic_polarity_t, vector: u64, c_id: [*c]u8, c_setvar_id: ?[*:0]u8) ?*anyopaque {
     const irq = allocator.create(Irq) catch @panic("OOM");
     var options: Irq.IoapicOptions = .{};
     if (c_polarity != null) {
@@ -354,6 +357,9 @@ export fn sdfgen_irq_ioapic_create(ioapic: u64, pin: u64, c_trigger: [*c]binding
     if (c_id != null) {
         options.id = c_id.*;
     }
+    if (c_setvar_id) |s| {
+        options.setvar_id = allocator.dupe(u8, std.mem.span(s)) catch @panic("OOM");
+    }
     options.ioapic = ioapic;
 
     irq.* = Irq.createIoapic(pin, vector, options) catch |e| {
@@ -365,11 +371,14 @@ export fn sdfgen_irq_ioapic_create(ioapic: u64, pin: u64, c_trigger: [*c]binding
     return irq;
 }
 
-export fn sdfgen_irq_msi_create(pci_bus: u8, pci_device: u8, pci_func: u8, vector: u64, handle: u64, c_id: [*c]u8) ?*anyopaque {
+export fn sdfgen_irq_msi_create(pci_bus: u8, pci_device: u8, pci_func: u8, vector: u64, handle: u64, c_id: [*c]u8, c_setvar_id: ?[*:0]u8) ?*anyopaque {
     const irq = allocator.create(Irq) catch @panic("OOM");
     var options: Irq.MsiOptions = .{};
     if (c_id != null) {
         options.id = c_id.*;
+    }
+    if (c_setvar_id) |s| {
+        options.setvar_id = allocator.dupe(u8, std.mem.span(s)) catch @panic("OOM");
     }
 
     irq.* = Irq.createMsi(pci_bus, pci_device, pci_func, vector, handle, options) catch |e| {
@@ -383,6 +392,9 @@ export fn sdfgen_irq_msi_create(pci_bus: u8, pci_device: u8, pci_func: u8, vecto
 
 export fn sdfgen_irq_destroy(c_irq: *align(8) anyopaque) void {
     const irq: *Irq = @ptrCast(c_irq);
+    if (irq.setvar_id) |s| {
+        allocator.free(s);
+    }
     allocator.destroy(irq);
 }
 
@@ -444,7 +456,7 @@ export fn sdfgen_mr_destroy(c_mr: *align(8) anyopaque) void {
     allocator.destroy(mr);
 }
 
-export fn sdfgen_map_create(c_mr: *align(8) anyopaque, vaddr: u64, c_perms: bindings.sdfgen_map_perms_t, cached: bool) ?*anyopaque {
+export fn sdfgen_map_create(c_mr: *align(8) anyopaque, vaddr: u64, c_perms: bindings.sdfgen_map_perms_t, cached: bool, c_setvar_vaddr: [*c]u8, c_setvar_size: ?[*:0]u8) ?*anyopaque {
     const mr: *Mr = @ptrCast(c_mr);
 
     var perms: Map.Perms = .{};
@@ -458,10 +470,18 @@ export fn sdfgen_map_create(c_mr: *align(8) anyopaque, vaddr: u64, c_perms: bind
         perms.execute = true;
     }
 
+    var options: Map.Options = .{.cached = cached};
+    if (c_setvar_vaddr) |s| {
+        options.setvar_vaddr = allocator.dupe(u8, std.mem.span(s)) catch @panic("OOM");
+    }
+    if (c_setvar_size) |s| {
+        options.setvar_size = allocator.dupe(u8, std.mem.span(s)) catch @panic("OOM");
+    }
+
     const map = allocator.create(Map) catch @panic("OOM");
     // TODO: I think we got some memory problems if we're dereferencing this stuff since
     // we need MemoryRegion to still be valid the whole time since we depend on it
-    map.* = Map.create(mr.*, vaddr, perms, .{ .cached = cached });
+    map.* = Map.create(mr.*, vaddr, perms, options);
 
     return map;
 }
@@ -473,10 +493,16 @@ export fn sdfgen_map_get_vaddr(c_map: *align(8) anyopaque) u64 {
 
 export fn sdfgen_map_destroy(c_map: *align(8) anyopaque) void {
     const map: *Map = @ptrCast(c_map);
+    if (map.setvar_vaddr) |s| {
+        allocator.free(s);
+    }
+    if (map.setvar_size) |s| {
+        allocator.free(s);
+    }
     allocator.destroy(map);
 }
 
-export fn sdfgen_channel_create(c_pd_a: *align(8) anyopaque, c_pd_b: *align(8) anyopaque, pd_a_id: [*c]u8, pd_b_id: [*c]u8, pd_a_notify: [*c]bool, pd_b_notify: [*c]bool, c_pp: [*c]u8) ?*anyopaque {
+export fn sdfgen_channel_create(c_pd_a: *align(8) anyopaque, c_pd_b: *align(8) anyopaque, pd_a_id: [*c]u8, pd_b_id: [*c]u8, pd_a_notify: [*c]bool, pd_b_notify: [*c]bool, c_pp: [*c]u8, c_pd_a_setvar_id: ?[*:0]u8, c_pd_b_setvar_id: ?[*:0]u8) ?*anyopaque {
     const pd_a: *Pd = @ptrCast(c_pd_a);
     const pd_b: *Pd = @ptrCast(c_pd_b);
 
@@ -504,6 +530,12 @@ export fn sdfgen_channel_create(c_pd_a: *align(8) anyopaque, c_pd_b: *align(8) a
         };
         options.pp = pp;
     }
+    if (c_pd_a_setvar_id) |s| {
+        options.pd_a_setvar_id = allocator.dupe(u8, std.mem.span(s)) catch @panic("OOM");
+    }
+    if (c_pd_b_setvar_id) |s| {
+        options.pd_b_setvar_id = allocator.dupe(u8, std.mem.span(s)) catch @panic("OOM");
+    }
 
     const ch = allocator.create(Channel) catch @panic("OOM");
     ch.* = Channel.create(pd_a, pd_b, options) catch |e| {
@@ -526,6 +558,12 @@ export fn sdfgen_channel_get_pd_b_id(c_ch: *align(8) anyopaque) u8 {
 
 export fn sdfgen_channel_destroy(c_ch: *align(8) anyopaque) void {
     const ch: *Channel = @ptrCast(c_ch);
+    if (ch.pd_a_setvar_id) |s| {
+        allocator.free(s);
+    }
+    if (ch.pd_b_setvar_id) |s| {
+        allocator.free(s);
+    }
     allocator.destroy(ch);
 }
 

--- a/src/c/sdfgen.h
+++ b/src/c/sdfgen.h
@@ -80,9 +80,9 @@ typedef enum {
     IRQ_IOAPIC_POLARITY_ACTIVE_HIGH = 1,
 } sdfgen_irq_ioapic_polarity_t;
 
-void *sdfgen_irq_create(uint32_t number, sdfgen_irq_trigger_t *trigger, uint8_t *id);
-void *sdfgen_irq_ioapic_create(uint64_t ioapic_id, uint64_t pin, sdfgen_irq_trigger_t *trigger, sdfgen_irq_ioapic_polarity_t *polarity, uint8_t *id);
-void *sdfgen_irq_msi_create(uint8_t pci_bus, uint8_t pci_device, uint8_t pci_func, uint64_t vector, uint64_t handle, uint8_t *id);
+void *sdfgen_irq_create(uint32_t number, sdfgen_irq_trigger_t *trigger, uint8_t *id, char *setvar_vaddr, char *setvar_size);
+void *sdfgen_irq_ioapic_create(uint64_t ioapic_id, uint64_t pin, sdfgen_irq_trigger_t *trigger, sdfgen_irq_ioapic_polarity_t *polarity, uint8_t *id, char *setvar_vaddr, char *setvar_size);
+void *sdfgen_irq_msi_create(uint8_t pci_bus, uint8_t pci_device, uint8_t pci_func, uint64_t vector, uint64_t handle, uint8_t *id, char *setvar_vaddr, char *setvar_size);
 void sdfgen_irq_destroy(void *irq);
 
 void *sdfgen_ioport_create(uint16_t addr, uint16_t size, uint8_t *id);
@@ -94,7 +94,7 @@ uint64_t sdfgen_mr_get_size(void *mr);
 bool sdgen_mr_get_paddr(void *mr, uint64_t *paddr);
 void sdfgen_mr_destroy(void *mr);
 
-void *sdfgen_map_create(void *mr, uint64_t vaddr, sdfgen_map_perms_t perms, bool cached);
+void *sdfgen_map_create(void *mr, uint64_t vaddr, sdfgen_map_perms_t perms, bool cached, char *setvar_vaddr, char *setvar_size);
 uint64_t sdfgen_map_get_vaddr(void *map);
 void *sdfgen_map_destroy(void *map);
 

--- a/src/python/module.py
+++ b/src/python/module.py
@@ -79,7 +79,7 @@ libsdfgen.sdfgen_channel_get_pd_b_id.restype = c_uint8
 libsdfgen.sdfgen_channel_get_pd_b_id.argtypes = [c_void_p]
 
 libsdfgen.sdfgen_map_create.restype = c_void_p
-libsdfgen.sdfgen_map_create.argtypes = [c_void_p, c_uint64, MapPermsType, c_bool]
+libsdfgen.sdfgen_map_create.argtypes = [c_void_p, c_uint64, MapPermsType, c_bool, c_char_p, c_char_p]
 libsdfgen.sdfgen_map_get_vaddr.restype = c_uint64
 libsdfgen.sdfgen_map_get_vaddr.argtypes = [c_void_p]
 libsdfgen.sdfgen_map_destroy.restype = None
@@ -498,6 +498,7 @@ class SystemDescription:
                 libsdfgen.sdfgen_pd_set_stack_size(self._obj, stack_size)
             if cpu is not None:
                 libsdfgen.sdfgen_pd_set_cpu(self._obj, cpu)
+            self.keep_alive = set()
 
         @property
         def name(self) -> str:
@@ -526,9 +527,12 @@ class SystemDescription:
             return libsdfgen.sdfgen_pd_get_map_vaddr(self._obj, mr._obj)
 
         def add_map(self, map: SystemDescription.Map):
+            self.keep_alive.add(map)
             libsdfgen.sdfgen_pd_add_map(self._obj, map._obj)
 
         def add_irq(self, irq: SystemDescription.Irq) -> int:
+            self.keep_alive.add(irq)
+
             id = libsdfgen.sdfgen_pd_add_irq(self._obj, irq._obj)
             if id < 0:
                 raise Exception(f"failed to add IRQ to PD '{self.name}'")
@@ -620,9 +624,17 @@ class SystemDescription:
             perms: str,
             *,
             cached: bool = True,
+            setvar_vaddr: Optional[str] = None,
+            setvar_size: Optional[str] = None,
         ) -> None:
             c_perms = SystemDescription.Map._perms_to_c_bindings(perms)
-            self._obj = libsdfgen.sdfgen_map_create(mr._obj, vaddr, c_perms, cached)
+            c_setvar_vaddr = c_char_p(0)
+            if setvar_vaddr is not None:
+                c_setvar_vaddr = c_char_p(setvar_vaddr.encode("utf-8"))
+            c_setvar_size = c_char_p(0)
+            if setvar_size is not None:
+                c_setvar_size = c_char_p(setvar_size.encode("utf-8"))
+            self._obj = libsdfgen.sdfgen_map_create(mr._obj, vaddr, c_perms, cached, c_setvar_vaddr, c_setvar_size)
             if self._obj is None:
                 raise Exception("failed to create mapping")
 
@@ -680,10 +692,15 @@ class SystemDescription:
         def __init__(
             self,
             irq: int,
+            *,
             trigger: Optional[Trigger] = None,
             id: Optional[int] = None,
+            setvar_id: Optional[str] = None,
         ):
-            self._obj = libsdfgen.sdfgen_irq_create(irq, ffi_uint32_ptr(trigger), ffi_uint8_ptr(id))
+            c_setvar_id = c_char_p(0)
+            if setvar_id is not None:
+                c_setvar_id = c_char_p(setvar_id.encode("utf-8"))
+            self._obj = libsdfgen.sdfgen_irq_create(irq, ffi_uint32_ptr(trigger), ffi_uint8_ptr(id), c_setvar_id)
             if self._obj is None:
                 raise Exception("failed to create IRQ - Conventional type")
 
@@ -708,8 +725,12 @@ class SystemDescription:
             trigger: Optional[Trigger] = None,
             polarity: Optional[Polarity] = None,
             id: Optional[int] = None,
+            setvar_id: Optional[str] = None,
         ):
-            self._obj = libsdfgen.sdfgen_irq_ioapic_create(ioapic_id, pin, ffi_uint32_ptr(trigger), ffi_uint32_ptr(polarity), vector, ffi_uint8_ptr(id))
+            c_setvar_id = c_char_p(0)
+            if setvar_id is not None:
+                c_setvar_id = c_char_p(setvar_id.encode("utf-8"))
+            self._obj = libsdfgen.sdfgen_irq_ioapic_create(ioapic_id, pin, ffi_uint32_ptr(trigger), ffi_uint32_ptr(polarity), vector, ffi_uint8_ptr(id), c_setvar_id)
             if self._obj is None:
                 raise Exception("failed to create IRQ - IOAPIC type")
 
@@ -725,8 +746,12 @@ class SystemDescription:
             vector: int,
             handle: int,
             id: Optional[int] = None,
+            setvar_id: Optional[str] = None,
         ):
-            self._obj = libsdfgen.sdfgen_irq_msi_create(pci_bus, pci_device, pci_func, vector, handle, ffi_uint8_ptr(id))
+            c_setvar_id = c_char_p(0)
+            if setvar_id is not None:
+                c_setvar_id = c_char_p(setvar_id.encode("utf-8"))
+            self._obj = libsdfgen.sdfgen_irq_msi_create(pci_bus, pci_device, pci_func, vector, handle, ffi_uint8_ptr(id), c_setvar_id)
             if self._obj is None:
                 raise Exception("failed to create IRQ - MSI type")
 
@@ -763,6 +788,8 @@ class SystemDescription:
             pp_b: Optional[bool] = None,
             notify_a: Optional[bool] = None,
             notify_b: Optional[bool] = None,
+            pd_a_setvar_id: Optional[str] = None,
+            pd_b_setvar_id: Optional[str] = None,
         ) -> None:
             c_pp = None
             if pp_a is not None:
@@ -773,6 +800,14 @@ class SystemDescription:
             if pp_a is not None and pp_b is not None:
                 raise Exception("attempting to create channel with PP on both ends")
 
+            c_pd_a_setvar_id = c_char_p(0)
+            if pd_a_setvar_id is not None:
+                c_pd_a_setvar_id = c_char_p(pd_a_setvar_id.encode("utf-8"))
+
+            c_pd_b_setvar_id = c_char_p(0)
+            if pd_b_setvar_id is not None:
+                c_pd_b_setvar_id = c_char_p(pd_b_setvar_id.encode("utf-8"))
+
             self._obj = libsdfgen.sdfgen_channel_create(
                 a._obj,
                 b._obj,
@@ -781,6 +816,8 @@ class SystemDescription:
                 ffi_bool_ptr(notify_a),
                 ffi_bool_ptr(notify_b),
                 ffi_uint8_ptr(c_pp),
+                c_pd_a_setvar_id,
+                c_pd_b_setvar_id,
             )
             if self._obj is None:
                 raise Exception("failed to create channel")
@@ -802,6 +839,7 @@ class SystemDescription:
         Create a System Description
         """
         self._obj = libsdfgen.sdfgen_create(arch.value, paddr_top)
+        self.keep_alive = set()
 
     def __del__(self):
         if hasattr(self, "_obj"):
@@ -814,6 +852,7 @@ class SystemDescription:
         libsdfgen.sdfgen_add_mr(self._obj, mr._obj)
 
     def add_channel(self, ch: Channel):
+        self.keep_alive.add(ch)
         libsdfgen.sdfgen_add_channel(self._obj, ch._obj)
 
     def render(self) -> str:

--- a/src/sdf.zig
+++ b/src/sdf.zig
@@ -204,10 +204,12 @@ pub const SystemDescription = struct {
         perms: Perms,
         cached: ?bool,
         setvar_vaddr: ?[]const u8,
+        setvar_size: ?[]const u8,
 
         pub const Options = struct {
             cached: ?bool = null,
             setvar_vaddr: ?[]const u8 = null,
+            setvar_size: ?[]const u8 = null,
         };
 
         pub const Perms = packed struct {
@@ -289,6 +291,7 @@ pub const SystemDescription = struct {
                 .perms = perms,
                 .cached = options.cached,
                 .setvar_vaddr = options.setvar_vaddr,
+                .setvar_size = options.setvar_size,
             };
         }
 
@@ -299,6 +302,10 @@ pub const SystemDescription = struct {
 
             if (map.setvar_vaddr) |setvar_vaddr| {
                 try std.fmt.format(writer, " setvar_vaddr=\"{s}\"", .{setvar_vaddr});
+            }
+
+            if (map.setvar_size) |setvar_size| {
+                try std.fmt.format(writer, " setvar_size=\"{s}\"", .{setvar_size});
             }
 
             if (map.cached) |cached| {
@@ -687,6 +694,8 @@ pub const SystemDescription = struct {
         pd_a_notify: ?bool,
         pd_b_notify: ?bool,
         pp: ?End,
+        pd_a_setvar_id: ?[]const u8,
+        pd_b_setvar_id: ?[]const u8,
 
         pub const End = enum { a, b };
 
@@ -696,6 +705,8 @@ pub const SystemDescription = struct {
             pp: ?End = null,
             pd_a_id: ?u8 = null,
             pd_b_id: ?u8 = null,
+            pd_a_setvar_id: ?[]const u8 = null,
+            pd_b_setvar_id: ?[]const u8 = null,
         };
 
         pub fn create(pd_a: *ProtectionDomain, pd_b: *ProtectionDomain, options: Options) !Channel {
@@ -712,6 +723,9 @@ pub const SystemDescription = struct {
                 .pd_a_notify = options.pd_a_notify,
                 .pd_b_notify = options.pd_b_notify,
                 .pp = options.pp,
+                .pd_a_setvar_id = options.pd_a_setvar_id,
+                .pd_b_setvar_id = options.pd_b_setvar_id,
+
             };
         }
 
@@ -730,6 +744,11 @@ pub const SystemDescription = struct {
             if (ch.pp != null and ch.pp.? == .a) {
                 _ = try writer.write(" pp=\"true\"");
             }
+
+            if (ch.pd_a_setvar_id) |setvar_id| {
+                try std.fmt.format(writer, " setvar_id=\"{s}\"", .{setvar_id});
+            }
+
             _ = try writer.write(" />\n");
 
             try std.fmt.format(writer, "{s}<end pd=\"{s}\" id=\"{}\"", .{ child_separator, ch.pd_b.name, ch.pd_b_id });
@@ -740,6 +759,10 @@ pub const SystemDescription = struct {
 
             if (ch.pp != null and ch.pp.? == .b) {
                 _ = try writer.write(" pp=\"true\"");
+            }
+
+            if (ch.pd_b_setvar_id) |setvar_id| {
+                try std.fmt.format(writer, " setvar_id=\"{s}\"", .{setvar_id});
             }
 
             try std.fmt.format(writer, " />\n{s}</channel>\n", .{separator});
@@ -784,10 +807,12 @@ pub const SystemDescription = struct {
         /// IRQ on all architectures need to map to a channel
         id: ?u8,
         kind: Kind,
+        setvar_id: ?[]const u8 = null,
 
         pub const Options = struct {
             trigger: ?Trigger = null,
             id: ?u8 = null,
+            setvar_id: ?[]const u8 = null,
         };
 
         pub fn create(irq: u32, options: Options) Irq {
@@ -799,6 +824,7 @@ pub const SystemDescription = struct {
                         .trigger = options.trigger,
                     },
                 },
+                .setvar_id = options.setvar_id,
             };
         }
 
@@ -835,6 +861,7 @@ pub const SystemDescription = struct {
             trigger: ?Trigger = null,
             // Microkit channel ID
             id: ?u8 = null,
+            setvar_id: ?[]const u8 = null,
         };
 
         pub fn createIoapic(pin: u64, vector: u64, options: IoapicOptions) !Irq {
@@ -849,11 +876,13 @@ pub const SystemDescription = struct {
                         .vector = vector,
                     },
                 },
+                .setvar_id = options.setvar_id,
             };
         }
 
         pub const MsiOptions = struct {
             id: ?u8 = null,
+            setvar_id: ?[]const u8 = null,
         };
 
         pub fn createMsi(pci_bus: u8, pci_device: u8, pci_func: u8, vector: u64, handle: u64, options: MsiOptions) !Irq {
@@ -869,6 +898,7 @@ pub const SystemDescription = struct {
                         .handle = handle,
                     },
                 },
+                .setvar_id = options.setvar_id,
             };
         }
 
@@ -902,6 +932,9 @@ pub const SystemDescription = struct {
                 .msi => |m_irq| {
                     try std.fmt.format(writer, "pcidev=\"{}:{}.{}\" handle=\"{}\" vector=\"{}\" id=\"{}\"", .{ m_irq.pci_bus, m_irq.pci_dev, m_irq.pci_func, m_irq.handle, m_irq.vector, irq.id.? });
                 }
+            }
+            if (irq.setvar_id) |setvar_id| {
+                try std.fmt.format(writer, " setvar_id=\"{s}\"", .{setvar_id});
             }
 
             _ = try writer.write(" />\n");


### PR DESCRIPTION
Adds function arguments and struct fields throughout for adding `setvar_vaddr`, `setvar_size`, and `setvar_id` SDF attributes.

Depends on https://github.com/seL4/microkit/pull/338