### PR TITLE
zig build: use -Dcpu=baseline to fix illegal instn

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ class ZigBuilder(build_ext):
             "zig",
             "build",
             "c",
+            "-Dcpu=baseline",
             f"-Doptimize={optimize}",
             # Python expects us to always provide a dynamic library
             "-Dc-linkage=dynamic",


### PR DESCRIPTION
Without this Zig chooses to use the 'native' CPU which results in illegal instruction from builds on GitHub runners depending on which exact CPU the GitHub runner was using, which means that the builds can spuriously fail :)